### PR TITLE
added zPostgreSQLPostgresDatabase option

### DIFF
--- a/ZenPacks/zenoss/PostgreSQL/__init__.py
+++ b/ZenPacks/zenoss/PostgreSQL/__init__.py
@@ -24,6 +24,7 @@ from Products.ZenUtils.Utils import monkeypatch, zenPath
 
 class ZenPack(ZenPackBase):
     packZProperties = [
+        ('zPostgreSQLPostgresDatabase', 'postgres', 'string'),
         ('zPostgreSQLPort', 5432, 'int'),
         ('zPostgreSQLUsername', 'postgres', 'string'),
         ('zPostgreSQLPassword', '', 'password'),

--- a/ZenPacks/zenoss/PostgreSQL/modeler/plugins/zenoss/PostgreSQL.py
+++ b/ZenPacks/zenoss/PostgreSQL/modeler/plugins/zenoss/PostgreSQL.py
@@ -22,6 +22,7 @@ from ....util import PgHelper
 
 class PostgreSQL(PythonPlugin):
     deviceProperties = PythonPlugin.deviceProperties + (
+        'zPostgreSQLPostgresDatabase',
         'zPostgreSQLPort',
         'zPostgreSQLUsername',
         'zPostgreSQLPassword',
@@ -30,6 +31,7 @@ class PostgreSQL(PythonPlugin):
 
     def collect(self, device, unused):
         pg = PgHelper(
+            device.zPostgreSQLPostgresDatabase,
             device.manageIp,
             device.zPostgreSQLPort,
             device.zPostgreSQLUsername,
@@ -46,7 +48,7 @@ class PostgreSQL(PythonPlugin):
             return None
 
         for dbName in results['databases'].keys():
-            if dbName == 'postgres':
+            if dbName == device.zPostgreSQLPostgresDatabase:
                 continue
 
             results['databases'][dbName]['tables'] = {}

--- a/ZenPacks/zenoss/PostgreSQL/objects/objects.xml
+++ b/ZenPacks/zenoss/PostgreSQL/objects/objects.xml
@@ -26,7 +26,7 @@ postgresFailure
 4
 </property>
 <property type="string" id="commandTemplate" mode="w" >
-poll_postgres.py '${here/manageIp}' '${here/zPostgreSQLPort}' '${here/zPostgreSQLUsername}' '${here/zPostgreSQLPassword}' '${here/zPostgreSQLUseSSL}' database
+poll_postgres.py '${here/zPostgreSQLPostgresDatabase}' '${here/manageIp}' '${here/zPostgreSQLPort}' '${here/zPostgreSQLUsername}' '${here/zPostgreSQLPassword}' '${here/zPostgreSQLUseSSL}' database
 </property>
 <property type="int" id="cycletime" mode="w" >
 300
@@ -1992,7 +1992,7 @@ postgresFailure
 4
 </property>
 <property type="string" id="commandTemplate" mode="w" >
-poll_postgres.py '${here/manageIp}' '${here/zPostgreSQLPort}' '${here/zPostgreSQLUsername}' '${here/zPostgreSQLPassword}' '${here/zPostgreSQLUseSSL}' server
+poll_postgres.py '${here/zPostgreSQLPostgresDatabase}' '${here/manageIp}' '${here/zPostgreSQLPort}' '${here/zPostgreSQLUsername}' '${here/zPostgreSQLPassword}' '${here/zPostgreSQLUseSSL}' server
 </property>
 <property type="int" id="cycletime" mode="w" >
 300
@@ -3961,7 +3961,7 @@ postgresFailure
 4
 </property>
 <property type="string" id="commandTemplate" mode="w" >
-poll_postgres.py '${here/manageIp}' '${here/zPostgreSQLPort}' '${here/zPostgreSQLUsername}' '${here/zPostgreSQLPassword}' '${here/zPostgreSQLUseSSL}' table
+poll_postgres.py '${here/zPostgreSQLPostgresDatabase}' '${here/manageIp}' '${here/zPostgreSQLPort}' '${here/zPostgreSQLUsername}' '${here/zPostgreSQLPassword}' '${here/zPostgreSQLUseSSL}' table
 </property>
 <property type="int" id="cycletime" mode="w" >
 300

--- a/ZenPacks/zenoss/PostgreSQL/poll_postgres.py
+++ b/ZenPacks/zenoss/PostgreSQL/poll_postgres.py
@@ -24,13 +24,15 @@ from util import PgHelper
 
 
 class PostgresPoller(object):
+    _postgres_database = None
     _host = None
     _port = None
     _username = None
     _password = None
     _data = None
 
-    def __init__(self, host, port, username, password, ssl):
+    def __init__(self, postgres_database, host, port, username, password, ssl):
+        self._postgres_database = postgres_database
         self._host = host
         self._port = port
         self._username = username
@@ -77,6 +79,7 @@ class PostgresPoller(object):
             self._data = dict(events=[])
 
             pg = PgHelper(
+                self._postgres_database,
                 self._host,
                 self._port,
                 self._username,
@@ -84,8 +87,8 @@ class PostgresPoller(object):
                 self._ssl)
 
             self._data.update(
-                connectionLatency=pg.getConnectionLatencyForDatabase('postgres'),
-                queryLatency=pg.getQueryLatencyForDatabase('postgres'),
+                connectionLatency=pg.getConnectionLatencyForDatabase(self._postgres_database),
+                queryLatency=pg.getQueryLatencyForDatabase(self._postgres_database),
                 )
 
             # Calculated server-level stats.
@@ -218,7 +221,7 @@ if __name__ == '__main__':
 
     host = port = username = password = ssl = None
     try:
-        host, port, username, password, ssl = sys.argv[1:6]
+        postgres_database, host, port, username, password, ssl = sys.argv[1:7]
     except ValueError:
         print >> sys.stderr, usage.format(sys.argv[0])
         sys.exit(1)
@@ -226,5 +229,5 @@ if __name__ == '__main__':
     if ssl == 'False':
         ssl = False
 
-    poller = PostgresPoller(host, port, username, password, ssl)
+    poller = PostgresPoller(postgres_database, host, port, username, password, ssl)
     poller.printJSON()

--- a/ZenPacks/zenoss/PostgreSQL/util.py
+++ b/ZenPacks/zenoss/PostgreSQL/util.py
@@ -79,6 +79,7 @@ from pg8000 import DBAPI
 
 
 class PgHelper(object):
+    _postgres_database = None
     _host = None
     _port = None
     _username = None
@@ -86,7 +87,8 @@ class PgHelper(object):
     _ssl = None
     _connections = None
 
-    def __init__(self, host, port, username, password, ssl):
+    def __init__(self, postgres_database, host, port, username, password, ssl):
+        self._postgres_database = postgres_database
         self._host = host
         self._port = port
         self._username = username
@@ -133,7 +135,7 @@ class PgHelper(object):
         return self._connections[db]['connection']
 
     def getDatabases(self):
-        cursor = self.getConnection('postgres').cursor()
+        cursor = self.getConnection(self._postgres_database).cursor()
 
         databases = {}
 
@@ -156,7 +158,7 @@ class PgHelper(object):
         return databases
 
     def getDatabaseStats(self):
-        cursor = self.getConnection('postgres').cursor()
+        cursor = self.getConnection(self._postgres_database).cursor()
 
         databaseStats = {}
 
@@ -241,7 +243,7 @@ class PgHelper(object):
         return tables
 
     def getConnectionStats(self):
-        cursor = self.getConnection('postgres').cursor()
+        cursor = self.getConnection(self._postgres_database).cursor()
 
         connectionStats = dict(databases={})
 
@@ -396,7 +398,7 @@ class PgHelper(object):
         return connectionStats
 
     def getLocks(self):
-        cursor = self.getConnection('postgres').cursor()
+        cursor = self.getConnection(self._postgres_database).cursor()
 
         locksTemplate = dict(
             locksTotal=0,


### PR DESCRIPTION
We are using puppet enterprise which names the postgres database 'pe-postgres', so we created this patch to enable an alternative 'postgres' database name.
