### PR TITLE
Change getLocks' query

### DIFF
--- a/ZenPacks/zenoss/PostgreSQL/util.py
+++ b/ZenPacks/zenoss/PostgreSQL/util.py
@@ -429,7 +429,7 @@ class PgHelper(object):
             cursor.execute(
                 "SELECT d.datname, l.mode, l.granted"
                 "  FROM pg_database AS d"
-                "  LEFT JOIN pg_locks AS l ON l.database = d.oid"
+                "  INNER JOIN pg_locks AS l ON l.database = d.oid"
                 " WHERE NOT d.datistemplate AND d.datallowconn"
             )
 


### PR DESCRIPTION
The query is using a LEFT join which is a LEFT outer join really, so it returns databases which don't have a lock with the mode and granted column as null.

Changed the LEFT join to INNER join to fix the problem
