### PR TITLE
Handle null data by skipping it.

### DIFF
--- a/ZenPacks/zenoss/PostgreSQL/poll_postgres.py
+++ b/ZenPacks/zenoss/PostgreSQL/poll_postgres.py
@@ -29,6 +29,9 @@ def clean_dict_data(d):
         elif isinstance(v, dict):
             # recurse
             fixed.update({k: clean_dict_data(v)})
+        # If Null data exists, just skip it, rather than bias datapoints.
+        elif v is None:
+            continue
         else:
             # no conversion needed, replace
             fixed.update({k: v})


### PR DESCRIPTION
Some newer versions of Pgsql now put Null's in stats that have not collected. We skip this data rather than bias an unknown variable with a 0. 
