### PR TITLE
Filter out BDR tables on Postgres-BDR

### DIFF
--- a/ZenPacks/zenoss/PostgreSQL/util.py
+++ b/ZenPacks/zenoss/PostgreSQL/util.py
@@ -143,6 +143,7 @@ class PgHelper(object):
                 "  FROM pg_database AS d"
                 "  JOIN pg_stat_database AS s ON s.datname = d.datname"
                 " WHERE NOT datistemplate AND datallowconn"
+                "   AND d.datname != 'bdr_supervisordb'"
             )
 
             for row in cursor.fetchall():
@@ -171,6 +172,7 @@ class PgHelper(object):
                 "       tup_updated, tup_deleted"
                 "  FROM pg_database AS d"
                 "  JOIN pg_stat_database AS s ON s.datname = d.datname"
+                "    AND d.datname != 'bdr_supervisordb'"
                 " WHERE NOT datistemplate AND datallowconn"
             )
 
@@ -253,6 +255,7 @@ class PgHelper(object):
                 "SELECT datname, xact_start, query_start, backend_start,"
                 "       now() AS now"
                 "  FROM pg_stat_activity"
+                "  WHERE datname !='bdr_supervisordb'"
             )
 
             connectionStats.update(
@@ -434,7 +437,8 @@ class PgHelper(object):
                 "  FROM pg_database AS d"
                 "  INNER JOIN pg_locks AS l ON l.database = d.oid"
                 " WHERE NOT d.datistemplate AND d.datallowconn"
-                " AND pid <> pg_backend_pid()"
+                "   AND d.datname != 'bdr_supervisordb'"
+                "   AND pid <> pg_backend_pid()"
             )
 
             locks.update(locksTemplate)

--- a/docs/body.md
+++ b/docs/body.md
@@ -153,12 +153,16 @@ SELECT relname, relid, schemaname,
 Changes
 ---------------
 
-1.0.9 (2017-04-27)
+1.0.10
+
+* Add support for Bi-Directional Replication (ZPS-249)
+
+1.0.9
 
 * Filter PIDs for lock query (ZEN-15165)
 * Guard against locks in PGSQL poller (ZPS-312)
 
-1.0.8 (2014-11.06)
+1.0.8
 
 * Handle null data by skipping it (ZEN-14276)
 * Update pg8000 lib to 1.9.14 (ZEN-12752)


### PR DESCRIPTION
Fixes ZPS-249

* When using Bi-Directional Replication for PostgreSQL,
  the protected bdr tables don't allow query for data,
  which leads to an error::

      postgres failure: ('FATAL', '42939', 'The BDR extension reserves the
      database bdr_supervisordb for its own use')"

* For non-BDR systems, we can't allow access on the non-existant
  database so this solution simply filters out databases with name
  'bdr_supervisordb', which raises no psql error.
  