### PR TITLE
Allow non-default name for the default database

### DIFF
--- a/ZenPacks/zenoss/PostgreSQL/__init__.py
+++ b/ZenPacks/zenoss/PostgreSQL/__init__.py
@@ -28,6 +28,7 @@ class ZenPack(ZenPackBase):
         ('zPostgreSQLUsername', 'postgres', 'string'),
         ('zPostgreSQLPassword', '', 'password'),
         ('zPostgreSQLUseSSL', False, 'boolean'),
+        ('zPostgreSQLDefaultDB', 'postgres', 'string'),
     ]
 
     def install(self, app):

--- a/ZenPacks/zenoss/PostgreSQL/modeler/plugins/zenoss/PostgreSQL.py
+++ b/ZenPacks/zenoss/PostgreSQL/modeler/plugins/zenoss/PostgreSQL.py
@@ -26,6 +26,7 @@ class PostgreSQL(PythonPlugin):
         'zPostgreSQLUsername',
         'zPostgreSQLPassword',
         'zPostgreSQLUseSSL',
+        'zPostgreSQLDefaultDB',
     )
 
     def collect(self, device, unused):
@@ -34,7 +35,8 @@ class PostgreSQL(PythonPlugin):
             device.zPostgreSQLPort,
             device.zPostgreSQLUsername,
             device.zPostgreSQLPassword,
-            device.zPostgreSQLUseSSL)
+            device.zPostgreSQLUseSSL,
+            device.zPostgreSQLDefaultDB)
 
         results = {}
 
@@ -46,7 +48,7 @@ class PostgreSQL(PythonPlugin):
             return None
 
         for dbName in results['databases'].keys():
-            if dbName == 'postgres':
+            if dbName == device.zPostgreSQLDefaultDB:
                 continue
 
             results['databases'][dbName]['tables'] = {}

--- a/ZenPacks/zenoss/PostgreSQL/objects/objects.xml
+++ b/ZenPacks/zenoss/PostgreSQL/objects/objects.xml
@@ -26,7 +26,7 @@ postgresFailure
 4
 </property>
 <property type="string" id="commandTemplate" mode="w" >
-poll_postgres.py '${here/manageIp}' '${here/zPostgreSQLPort}' '${here/zPostgreSQLUsername}' '${here/zPostgreSQLPassword}' '${here/zPostgreSQLUseSSL}' database
+poll_postgres.py '${here/manageIp}' '${here/zPostgreSQLPort}' '${here/zPostgreSQLUsername}' '${here/zPostgreSQLPassword}' '${here/zPostgreSQLUseSSL}' '${here/zPostgreSQLDefaultDB}' database
 </property>
 <property type="int" id="cycletime" mode="w" >
 300
@@ -1992,7 +1992,7 @@ postgresFailure
 4
 </property>
 <property type="string" id="commandTemplate" mode="w" >
-poll_postgres.py '${here/manageIp}' '${here/zPostgreSQLPort}' '${here/zPostgreSQLUsername}' '${here/zPostgreSQLPassword}' '${here/zPostgreSQLUseSSL}' server
+poll_postgres.py '${here/manageIp}' '${here/zPostgreSQLPort}' '${here/zPostgreSQLUsername}' '${here/zPostgreSQLPassword}' '${here/zPostgreSQLUseSSL}' '${here/zPostgreSQLDefaultDB}' server
 </property>
 <property type="int" id="cycletime" mode="w" >
 300
@@ -3961,7 +3961,7 @@ postgresFailure
 4
 </property>
 <property type="string" id="commandTemplate" mode="w" >
-poll_postgres.py '${here/manageIp}' '${here/zPostgreSQLPort}' '${here/zPostgreSQLUsername}' '${here/zPostgreSQLPassword}' '${here/zPostgreSQLUseSSL}' table
+poll_postgres.py '${here/manageIp}' '${here/zPostgreSQLPort}' '${here/zPostgreSQLUsername}' '${here/zPostgreSQLPassword}' '${here/zPostgreSQLUseSSL}' '${here/zPostgreSQLDefaultDB}' table
 </property>
 <property type="int" id="cycletime" mode="w" >
 300

--- a/ZenPacks/zenoss/PostgreSQL/poll_postgres.py
+++ b/ZenPacks/zenoss/PostgreSQL/poll_postgres.py
@@ -42,20 +42,22 @@ class PostgresPoller(object):
     _port = None
     _username = None
     _password = None
+    _default_db = None
 
-    def __init__(self, host, port, username, password, ssl):
+    def __init__(self, host, port, username, password, ssl, default_db):
         self._host = host
         self._port = port
         self._username = username
         self._password = password
         self._ssl = ssl
+        self._default_db = default_db
 
     def getData(self, pg):
         data = dict(events=[])
 
         data.update(
-            connectionLatency=pg.getConnectionLatencyForDatabase('postgres'),
-            queryLatency=pg.getQueryLatencyForDatabase('postgres'),
+            connectionLatency=pg.getConnectionLatencyForDatabase(self._default_db),
+            queryLatency=pg.getQueryLatencyForDatabase(self._default_db),
             )
 
         # Calculated server-level stats.
@@ -162,7 +164,9 @@ class PostgresPoller(object):
                 self._port,
                 self._username,
                 self._password,
-                self._ssl)
+                self._ssl,
+                self._default_db
+                )
 
             data = self.getData(pg)
             data['events'].append(dict(
@@ -196,11 +200,11 @@ class PostgresPoller(object):
         print json.dumps(clean_dict_data(data))
 
 if __name__ == '__main__':
-    usage = "Usage: {0} <host> <port> <username> <password <ssl>"
+    usage = "Usage: {0} <host> <port> <username> <password <ssl> <defaultDB>"
 
-    host = port = username = password = ssl = None
+    host = port = username = password = ssl = default_db = None
     try:
-        host, port, username, password, ssl = sys.argv[1:6]
+        host, port, username, password, ssl, default_db = sys.argv[1:7]
     except ValueError:
         print >> sys.stderr, usage.format(sys.argv[0])
         sys.exit(1)
@@ -208,5 +212,5 @@ if __name__ == '__main__':
     if ssl == 'False':
         ssl = False
 
-    poller = PostgresPoller(host, port, username, password, ssl)
+    poller = PostgresPoller(host, port, username, password, ssl, default_db)
     poller.printJSON()

--- a/ZenPacks/zenoss/PostgreSQL/util.py
+++ b/ZenPacks/zenoss/PostgreSQL/util.py
@@ -84,14 +84,16 @@ class PgHelper(object):
     _username = None
     _password = None
     _ssl = None
+    _default_db = None
     _connections = None
 
-    def __init__(self, host, port, username, password, ssl):
+    def __init__(self, host, port, username, password, ssl, default_db):
         self._host = host
         self._port = port
         self._username = username
         self._password = password
         self._ssl = ssl
+        self._default_db = default_db
         self._connections = {}
 
     def close(self):
@@ -133,7 +135,7 @@ class PgHelper(object):
         return self._connections[db]['connection']
 
     def getDatabases(self):
-        cursor = self.getConnection('postgres').cursor()
+        cursor = self.getConnection(self._default_db).cursor()
 
         databases = {}
 
@@ -157,7 +159,7 @@ class PgHelper(object):
         return databases
 
     def getDatabaseStats(self):
-        cursor = self.getConnection('postgres').cursor()
+        cursor = self.getConnection(self._default_db).cursor()
 
         databaseStats = {}
 
@@ -246,7 +248,7 @@ class PgHelper(object):
         return tables
 
     def getConnectionStats(self):
-        cursor = self.getConnection('postgres').cursor()
+        cursor = self.getConnection(self._default_db).cursor()
 
         connectionStats = dict(databases={})
 
@@ -402,7 +404,7 @@ class PgHelper(object):
         return connectionStats
 
     def getLocks(self):
-        cursor = self.getConnection('postgres').cursor()
+        cursor = self.getConnection(self._default_db).cursor()
 
         locksTemplate = dict(
             locksTotal=0,

--- a/docs/body.md
+++ b/docs/body.md
@@ -81,6 +81,7 @@ individual devices.
      - *zPostgreSQLUseSSL* - Whether to use SSL or not. Default: False
      - *zPostgreSQLUsername* - Must be a superuser. Default: postgres
      - *zPostgreSQLPassword* - Password for user. No default.
+     - *zPostgreSQLDefaultDB* - Default database. Default: postgres
 
 In addition to setting these properties you must add the ''zenoss.PostgreSQL''
 modeler plugin to a device class or individual device. This modeler plugin will
@@ -156,6 +157,10 @@ Changes
 1.0.10
 
 * Add support for Bi-Directional Replication (ZPS-249)
+* Add support variable default database name (ZPS-2767)
+* Added zProperties:
+
+    - zPostgreSQLDefaultDB: Sets default database for administration data
 
 1.0.9
 


### PR DESCRIPTION
* Fixes ZPS-2767

Normally, PostgreSQL uses a default database name of 'postgres'
for its internal administration, user, table accounting.
Some systems like Puppet Enterprise maintain non-default names.

We add the zproperty, zPostgreSQLDefaultDB, to allow for a non-default
value. The default value for zPostgreSQLDefaultDB remains as 'postgres'.