### PR TITLE
Add Known Issues for ZEN-29375

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@ OUTPUT_HTML = /tmp/README.html
 
 docs:
 	cat top.css > $(OUTPUT_HTML)
-	pandoc -f markdown_github -t html header.md --template=template.html >> $(OUTPUT_HTML)
-	pandoc -f markdown_github -t html releases.md --template=template.html >> $(OUTPUT_HTML)
-	pandoc -f markdown_github -t html body.md --template=template.html --table-of-contents >> $(OUTPUT_HTML)
+	pandoc -f markdown_github-hard_line_breaks -t html header.md --template=template.html >> $(OUTPUT_HTML)
+	pandoc -f markdown_github-hard_line_breaks -t html releases.md --template=template.html >> $(OUTPUT_HTML)
+	pandoc -f markdown_github-hard_line_breaks -t html body.md --template=template.html --table-of-contents >> $(OUTPUT_HTML)
 	python docs.py

--- a/docs/body.md
+++ b/docs/body.md
@@ -148,8 +148,18 @@ SELECT relname, relid, schemaname,
        pg_relation_size(relid) AS size,
        pg_total_relation_size(relid) AS total_size
   FROM pg_stat_user_tables
-</syntaxhighlight>
 ```
+
+Limitations
+---------------
+
+### Troubleshooting Modeling
+
+If the device fails to model PostgreSQL components with the error:
+"WARNING zen.ZenModeler: Python client creation failed" you can either
+1) clear the events and remodel the device or 2) set the
+zSnmpMonitorIgnore property to True and remodel.
+
 
 Changes
 ---------------


### PR DESCRIPTION
* Workaround for ZEN-29375

In Zenoss 6.0, if the base OS has a failed plugin, it will prevent
the PostgreSQL python plugin from modeling. We include a Known issues
section here to workaround this issues.