### PR TITLE
fix to support postgres versionnumber with text

### DIFF
--- a/src/pg8000/pg8000/core.py
+++ b/src/pg8000/pg8000/core.py
@@ -62,6 +62,7 @@ from uuid import UUID
 from copy import deepcopy
 from calendar import timegm
 import os
+import re
 
 ZERO = timedelta(0)
 
@@ -1710,8 +1711,11 @@ class Connection(object):
                 self.pg_types[1186] = (FC_BINARY, interval_recv_float)
 
         elif key == b("server_version"):
+            # version string can fx. be "10.2 (Ubuntu 10.2-1.pgdg16.04+1)", so
+            # regex the elements that tell which DB version we are running
+            version_string = re.match('^[0-9\.]+',value.decode("ascii")).group(0)
             self._server_version = tuple(
-                map(int, value.decode("ascii").split('.')[:2]))
+                map(int, version_string.decode("ascii").split('.')[:2]))
             if self._server_version[0] == 8:
                 if self._server_version[1] > 1:
                     self._commands_with_count = (


### PR DESCRIPTION
We discovered that when trying to monitor a PostgreSQL 10 database installed on an Ubuntu server, the postgresql version was: 10.2 (Ubuntu 10.2-1.pgdg16.04+1)
This makes the poll_postgres.py to fail with: {"events": [{"eventClassKey": "postgresFailure", "summary": "postgres failure: invalid literal for int() with base 10: '2 (Ubuntu 10'", "severity": 4, "eventKey": "postgresFailure"}]}
This pull-request will modify the core.py from pg8000 to only work on the version number of postgres by regex'ing everything else but number away.
I have tested the fix on PostgreSQL versions:
9.5.2
9.6
10.2

All on Zenoss 4.2.5.
