### PR TITLE
Fix call to poll_postgres.py script

### DIFF
--- a/ZenPacks/zenoss/PostgreSQL/objects/objects.xml
+++ b/ZenPacks/zenoss/PostgreSQL/objects/objects.xml
@@ -26,7 +26,7 @@ postgresFailure
 4
 </property>
 <property type="string" id="commandTemplate" mode="w" >
-poll_postgres.py '${here/manageIp}' '${here/zPostgreSQLPort}' '${here/zPostgreSQLUsername}' '${here/zPostgreSQLPassword}' '${here/zPostgreSQLUseSSL}' '${here/zPostgreSQLDefaultDB}' database
+/opt/zenoss/bin/python ${here/ZenPackManager/packs/ZenPacks.zenoss.PostgreSQL/path}/poll_postgres.py '${here/manageIp}' '${here/zPostgreSQLPort}' '${here/zPostgreSQLUsername}' '${here/zPostgreSQLPassword}' '${here/zPostgreSQLUseSSL}' '${here/zPostgreSQLDefaultDB}' database
 </property>
 <property type="int" id="cycletime" mode="w" >
 300
@@ -1992,7 +1992,7 @@ postgresFailure
 4
 </property>
 <property type="string" id="commandTemplate" mode="w" >
-poll_postgres.py '${here/manageIp}' '${here/zPostgreSQLPort}' '${here/zPostgreSQLUsername}' '${here/zPostgreSQLPassword}' '${here/zPostgreSQLUseSSL}' '${here/zPostgreSQLDefaultDB}' server
+/opt/zenoss/bin/python ${here/ZenPackManager/packs/ZenPacks.zenoss.PostgreSQL/path}/poll_postgres.py '${here/manageIp}' '${here/zPostgreSQLPort}' '${here/zPostgreSQLUsername}' '${here/zPostgreSQLPassword}' '${here/zPostgreSQLUseSSL}' '${here/zPostgreSQLDefaultDB}' server
 </property>
 <property type="int" id="cycletime" mode="w" >
 300
@@ -3961,7 +3961,7 @@ postgresFailure
 4
 </property>
 <property type="string" id="commandTemplate" mode="w" >
-poll_postgres.py '${here/manageIp}' '${here/zPostgreSQLPort}' '${here/zPostgreSQLUsername}' '${here/zPostgreSQLPassword}' '${here/zPostgreSQLUseSSL}' '${here/zPostgreSQLDefaultDB}' table
+/opt/zenoss/bin/python ${here/ZenPackManager/packs/ZenPacks.zenoss.PostgreSQL/path}/poll_postgres.py '${here/manageIp}' '${here/zPostgreSQLPort}' '${here/zPostgreSQLUsername}' '${here/zPostgreSQLPassword}' '${here/zPostgreSQLUseSSL}' '${here/zPostgreSQLDefaultDB}' table
 </property>
 <property type="int" id="cycletime" mode="w" >
 300


### PR DESCRIPTION
As is, the monitoring templates fail with an error that the command isn't found (at least on Zenoss 6.4.1), since zencommand expects scripts to be installed into /opt/zenoss/libexec. Other ZenPacks install a symlink pointing to the actual check script (see, e.g. ZenPacks.zenoss.CiscoMonitor or ZenPacks.zenoss.Memcached), but this is a quick fix that shouldn't risk breaking anything.

The script also doesn't have the execute bit set, so this calls zenoss's python binary.

* Resolve full path to poll_postgres.py script using ZenPackManager
* Call script using zenoss python, since file isn't marked executable