### PR TITLE
Correct relative imports in poll_postgres.py

### DIFF
--- a/ZenPacks/zenoss/PostgreSQL/libexec/poll_postgres.py
+++ b/ZenPacks/zenoss/PostgreSQL/libexec/poll_postgres.py
@@ -17,7 +17,9 @@ import json
 import sys
 import decimal
 
-from ZenPacks.zenoss.PostgreSQL.util import PgHelper
+from os import path
+sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+from util import PgHelper
 
 
 def clean_dict_data(d):


### PR DESCRIPTION
Fixes ZPS-6818

After moving the script poll_postgres.py to a separate directory, it was 
not able to import the dependent classes, because it was running in an
isolated shell. As a solution, parent directory  added to PYTHONPATH