### PR TITLE
Added patch for PostgreSQL driver

### DIFF
--- a/ZenPacks/zenoss/PostgreSQL/__init__.py
+++ b/ZenPacks/zenoss/PostgreSQL/__init__.py
@@ -33,6 +33,7 @@ class ZenPack(ZenPackBase):
 
     def install(self, app):
         super(ZenPack, self).install(app)
+        self.patchPostgreSQLDriver()
         self.updateExistingRelations(app.zport.dmd)
 
     def remove(self, app, leaveObjects=False):
@@ -42,6 +43,9 @@ class ZenPack(ZenPackBase):
                 [ x for x in Device._relations if x[0] != 'pgDatabases' ])
 
             self.updateExistingRelations(app.zport.dmd)
+        
+        # Revert all pg8000 library patches
+        self.patchPostgreSQLDriver(revert=True)
 
         super(ZenPack, self).remove(app, leaveObjects=leaveObjects)
 
@@ -49,6 +53,20 @@ class ZenPack(ZenPackBase):
         log.info('Adding pgDatabases relationship to existing devices')
         for device in dmd.Devices.getSubDevicesGen():
             device.buildRelations()
+
+    def patchPostgreSQLDriver(self, revert=False):
+        log.info('Patching pg8000 core library')
+        patch_dir = self.path('lib')
+        
+        # Getting a list of all patches which will be applied
+        patches_list = [file for file in os.listdir(patch_dir) if file.endswith('.patch')]
+        
+        cmd = "patch -p0 -d %s -i %s" if not revert else "patch -p0 -R -d %s -i %s"  
+        for patch in patches_list:
+            os.system(cmd % (
+                os.path.join(patch_dir, 'pg8000'),
+                os.path.join(patch_dir, patch)
+            ))
 
 # Allow PostgreSQL databases to be related to any device.
 Device._relations += (

--- a/ZenPacks/zenoss/PostgreSQL/lib/pg8000_core.patch
+++ b/ZenPacks/zenoss/PostgreSQL/lib/pg8000_core.patch
@@ -1,0 +1,23 @@
+--- core.py	2021-01-08 12:38:09.956495934 +0000
++++ patched_core.py	2021-01-08 14:45:06.722817791 +0000
+@@ -62,6 +62,7 @@
+ from copy import deepcopy
+ from calendar import timegm
+ import os
++import re
+ 
+ ZERO = timedelta(0)
+ 
+@@ -1710,8 +1711,11 @@
+                 self.pg_types[1186] = (FC_BINARY, interval_recv_float)
+ 
+         elif key == b("server_version"):
++            # version string can fx. be "10.2 (Ubuntu 10.2-1.pgdg16.04+1)", so
++            # regex the elements that tell which DB version we are 
++            version_string = re.match('^[0-9\.]+',value.decode("ascii")).group(0)
+             self._server_version = tuple(
+-                map(int, value.decode("ascii").split('.')[:2]))
++                map(int, version_string.decode("ascii").split('.')[:2]))
+             if self._server_version[0] == 8:
+                 if self._server_version[1] > 1:
+                     self._commands_with_count = (

--- a/ZenPacks/zenoss/PostgreSQL/lib/pg8000_core.patch
+++ b/ZenPacks/zenoss/PostgreSQL/lib/pg8000_core.patch
@@ -12,8 +12,8 @@
                  self.pg_types[1186] = (FC_BINARY, interval_recv_float)
  
          elif key == b("server_version"):
-+            # version string can fx. be "10.2 (Ubuntu 10.2-1.pgdg16.04+1)", so
-+            # regex the elements that tell which DB version we are 
++            # The posgresql server can return server version string in next format: "10.2 (Ubuntu 10.2-1.pgdg16.04+1)"
++            # so use regex extracting number of DB version 
 +            version_string = re.match('^[0-9\.]+',value.decode("ascii")).group(0)
              self._server_version = tuple(
 -                map(int, value.decode("ascii").split('.')[:2]))


### PR DESCRIPTION
Fixes ZPS-7424

pg8000 library we use doesn't parse correctly version of posgresql on ubuntu 10.
On Ubuntu starting from PostgreSQL 10+  it returns version in a following format "Ubuntu 10.2-1.pgdg16.04+1" what library doesn't handle.
As it is not fixed in the latest version of the library have to manually patch pg8000 lib to handle the case